### PR TITLE
Make Boss DB configurable via Rocket.toml.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.blosc
 upload/
 uploads/
+*.swp

--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ It is bewildering how much faster this is than the Python implementation.
 ## Feature Parity
 
 I'm planning to add a feature-parity document once it's not embarrassing.
+
+## Development
+
+Blosc must be installed manually via a package manager to build.
+
+For MacOs:
+
+```shell
+brew install c-blosc
+```

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,0 +1,5 @@
+[development]
+address = "localhost"
+port = 8090
+bosshost = "api.bossdb.io"
+

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -499,6 +499,7 @@ pub mod data_manager {
         /// * `token` - The token to use for ALL requests from this mgr
         ///
         pub fn new(protocol: String, host: String, token: String) -> BossDBRelayDataManager {
+            println!("host: {}", host);
             BossDBRelayDataManager {
                 protocol,
                 host,

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -499,7 +499,6 @@ pub mod data_manager {
         /// * `token` - The token to use for ALL requests from this mgr
         ///
         pub fn new(protocol: String, host: String, token: String) -> BossDBRelayDataManager {
-            println!("host: {}", host);
             BossDBRelayDataManager {
                 protocol,
                 host,


### PR DESCRIPTION
Use Rocket.toml for Boss DB host as well as standard settings such as IP
to listen on and port to use.

Not sure if the root of the repo is the best place to put the Rocket.toml file, but this makes it findable for the dev assuming `cargo run` is run from the root of the repo.