### PR TITLE
Add config module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,29 @@
 
 This is a reimplementation of the [Bossphorus](https://github.com/aplbrain/bossphorus) codebase in [Rust](https://www.rust-lang.org/).
 
+
 ## Why?
 
 It is bewildering how much faster this is than the Python implementation.
 
+
 ## Feature Parity
 
 I'm planning to add a feature-parity document once it's not embarrassing.
+
+
+## Configuration
+
+Environment variables have precedence over the `Rocket.toml` config file.
+
+### Environment Variables
+
+`BOSSHOST`: Sets the Boss DB host
+
+### Rocket.toml File
+
+`bosshost`: Sets the Boss DB host
+
 
 ## Development
 
@@ -20,3 +36,6 @@ For MacOs:
 ```shell
 brew install c-blosc
 ```
+
+Due to use of the Rocket web server crate, the nightly Rust toolchain must be
+used.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,35 @@
+pub mod config {
+    /// Configuration module.
+    ///
+    /// Gets custom config values from environment variables and the
+    /// Rocket.toml config file.  Values set as environment variables will
+    /// override like values in the config file.
+    use rocket::Rocket;
+    use std::env::{var};
+
+    /// The Boss host to talk to.
+    pub struct BossHost(pub String);
+
+    const BOSSHOST_ENV_NAME: &str = "BOSSHOST";
+    const BOSSHOST_ROCKET_CFG: &str = "bosshost";
+    const BOSSHOST_DEFAULT: &str = "api.bossdb.io";
+
+    /// Gets the Boss host to talk to.  First checks for an environment
+    /// variable.  Then checks for a value in the Rocket.toml file.
+    pub fn get_boss_host(rocket: Rocket) -> Result<Rocket, Rocket> {
+        let boss_host: String;
+        match var(BOSSHOST_ENV_NAME) {
+            Ok(val) => boss_host = val,
+            Err(e) => {
+                boss_host = rocket.config()
+                    .get_str(BOSSHOST_ROCKET_CFG)
+                    .unwrap_or(BOSSHOST_DEFAULT)
+                    .to_string();
+            },
+        }
+        // ToDo: make this visible to the user in a better place.
+        println!("Boss host: {}", boss_host);
+        Ok(rocket.manage(BossHost(boss_host)))
+    }
+}
+


### PR DESCRIPTION
Move config code out of main.rs and add support for configuring
bossphorust custom values via environment variables.

First check BOSSHOST environment variable before looking in Rocket.toml.
This will let users run bossphorust in a Docker container and still be
able to change the Boss DB w/o rebuilding the Docker image.