### PR TITLE
Sql usage manager

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,4 @@
-DATABASE_URL=mysql://root:MICrONS@localhost/bossphorust
+# This is an alternate way to set environment variables provided by the
+# `dotenv` create.  This is used by the Diesel CLI for convenience during
+# development.  This variable is not used by Bossphorus, itself.
+DATABASE_URL=./cache-db.sqlite

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=mysql://root:MICrONS@localhost/bossphorust

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 upload/
 uploads/
 *.swp
+*.sqlite

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,8 @@ name = "bossphorus"
 version = "0.0.1"
 dependencies = [
  "blosc",
+ "chrono",
+ "diesel",
  "ndarray",
  "reqwest",
  "rocket",
@@ -107,6 +109,17 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "chrono"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "time",
+]
 
 [[package]]
 name = "cookie"
@@ -166,6 +179,31 @@ dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
+]
+
+[[package]]
+name = "diesel"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d7ca63eb2efea87a7f56a283acc49e2ce4b2bd54adf7465dc1d81fef13d8fc"
+dependencies = [
+ "byteorder",
+ "chrono",
+ "diesel_derives",
+ "mysqlclient-sys",
+ "percent-encoding 2.1.0",
+ "url 2.1.1",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -661,6 +699,16 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "mysqlclient-sys"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9637d93448044078aaafea7419aed69d301b4a12bcc4aa0ae856eb169bef85"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,9 +190,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "diesel_derives",
- "mysqlclient-sys",
- "percent-encoding 2.1.0",
- "url 2.1.1",
+ "libsqlite3-sys",
 ]
 
 [[package]]
@@ -595,6 +593,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d90181c2904c287e5390186be820e5ef311a3c62edebb7d6ca3d6a48ce041d"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,16 +707,6 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
-]
-
-[[package]]
-name = "mysqlclient-sys"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9637d93448044078aaafea7419aed69d301b4a12bcc4aa0ae856eb169bef85"
-dependencies = [
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 [dependencies]
 blosc = "0.1.2"
+diesel = { version = "1.4.4", features = ["chrono", "mysql"] }
+chrono = "0.4.11"
 ndarray = "0.13.0"
 reqwest = { version = "0.10.4", features = ["blocking"] }
 rocket = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 blosc = "0.1.2"
-diesel = { version = "1.4.4", features = ["chrono", "mysql"] }
+diesel = { version = "1.4.4", features = ["chrono", "sqlite"] }
 chrono = "0.4.11"
 ndarray = "0.13.0"
 reqwest = { version = "0.10.4", features = ["blocking"] }

--- a/diesel.toml
+++ b/diesel.toml
@@ -1,0 +1,5 @@
+# For documentation on how to configure this file,
+# see diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "src/db/schema.rs"

--- a/diesel.toml
+++ b/diesel.toml
@@ -3,3 +3,6 @@
 
 [print_schema]
 file = "src/db/schema.rs"
+
+# Make primary key of cuboids table a BigInt.
+patch_file = "src/db/schema.patch"

--- a/migrations/2020-04-11-205010_cuboids/down.sql
+++ b/migrations/2020-04-11-205010_cuboids/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS cuboids;
+DROP TABLE IF EXISTS cache_roots;

--- a/migrations/2020-04-11-205010_cuboids/up.sql
+++ b/migrations/2020-04-11-205010_cuboids/up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE cache_roots (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    path VARCHAR(512) NOT NULL UNIQUE
+);
+
+CREATE TABLE cuboids (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    cache_root INT NOT NULL,
+    cube_key VARCHAR(512) NOT NULL,
+    requests INT NOT NULL,
+    created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_accessed TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    INDEX (cache_root),
+    FOREIGN KEY (cache_root)
+        REFERENCES cache_roots(id)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE,
+
+    INDEX (cube_key, cache_root)
+);

--- a/migrations/2020-04-11-205010_cuboids/up.sql
+++ b/migrations/2020-04-11-205010_cuboids/up.sql
@@ -1,21 +1,21 @@
 CREATE TABLE cache_roots (
-    id INT AUTO_INCREMENT PRIMARY KEY,
+    id INTEGER PRIMARY KEY NOT NULL,
     path VARCHAR(512) NOT NULL UNIQUE
 );
 
 CREATE TABLE cuboids (
-    id INT AUTO_INCREMENT PRIMARY KEY,
+    id INTEGER PRIMARY KEY NOT NULL,
     cache_root INT NOT NULL,
     cube_key VARCHAR(512) NOT NULL,
-    requests INT NOT NULL,
-    created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    last_accessed TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-
-    INDEX (cache_root),
+    requests BIGINT NOT NULL,
+    created TEXT DEFAULT CURRENT_TIMESTAMP,
+    last_accessed TEXT DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (cache_root)
         REFERENCES cache_roots(id)
         ON DELETE CASCADE
-        ON UPDATE CASCADE,
-
-    INDEX (cube_key, cache_root)
+        ON UPDATE CASCADE
 );
+
+CREATE UNIQUE INDEX cuboids_cache_root_index ON cuboids(cache_root);
+
+CREATE UNIQUE INDEX cuboids_key_cache_root_index on cuboids (cube_key, cache_root);

--- a/migrations/2020-04-11-205010_cuboids/up.sql
+++ b/migrations/2020-04-11-205010_cuboids/up.sql
@@ -16,6 +16,6 @@ CREATE TABLE cuboids (
         ON UPDATE CASCADE
 );
 
-CREATE UNIQUE INDEX cuboids_cache_root_index ON cuboids(cache_root);
+CREATE INDEX cuboids_cache_root_index ON cuboids(cache_root);
 
 CREATE UNIQUE INDEX cuboids_key_cache_root_index on cuboids (cube_key, cache_root);

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,30 @@
 /// Rocket.toml config file.  Values set as environment variables will
 /// override like values in the config file.
 use rocket::Rocket;
-use std::env::{var};
+use std::env;
+use std::fs;
+
+/// Store cuboid files off of this folder.  This is not a standard config
+/// variable because we will likely move to a separate config file as
+/// discussed in https://github.com/aplbrain/bossphorust/issues/11
+/// Thus, keeping this as a simple constant for now.
+pub const CUBOID_ROOT_PATH: &str = "uploads";
+
+pub fn get_cuboid_root_abs_path() -> String {
+    let path = fs::canonicalize(CUBOID_ROOT_PATH);
+    let path_str = match path {
+        Ok(p) => p,
+        Err(_) => {
+            fs::create_dir_all(CUBOID_ROOT_PATH)
+                .expect(&format!("Couldn't create {}", CUBOID_ROOT_PATH));
+            return get_cuboid_root_abs_path()
+        },
+    };
+    return match path_str.as_path().to_str() {
+        Some(s) => s.to_string(),
+        None => panic!("Non-unicode path given"),
+    }
+}
 
 /// The Boss host to talk to.
 pub struct BossHost(pub String);
@@ -17,7 +40,7 @@ const BOSSHOST_DEFAULT: &str = "api.bossdb.io";
 /// variable.  Then checks for a value in the Rocket.toml file.
 pub fn get_boss_host(rocket: Rocket) -> Result<Rocket, Rocket> {
     let boss_host: String;
-    match var(BOSSHOST_ENV_NAME) {
+    match env::var(BOSSHOST_ENV_NAME) {
         Ok(val) => boss_host = val,
         Err(_) => {
             boss_host = rocket.config()
@@ -43,7 +66,7 @@ const BOSSTOKEN_DEFAULT: &str = "public";
 /// variable.  Then checks for a value in the Rocket.toml file.
 pub fn get_boss_token(rocket: Rocket) -> Result<Rocket, Rocket> {
     let boss_token: String;
-    match var(BOSSTOKEN_ENV_NAME) {
+    match env::var(BOSSTOKEN_ENV_NAME) {
         Ok(val) => boss_token = val,
         Err(_) => {
             boss_token = rocket.config()
@@ -66,7 +89,7 @@ const USAGE_MGR_DEFAULT: &str = "none";
 /// variable.  Then checks for a value in the Rocket.toml file.
 pub fn get_usage_mgr(rocket: Rocket) -> Result<Rocket, Rocket> {
     let usage_mgr: String;
-    match var(USAGE_MGR_ENV_NAME) {
+    match env::var(USAGE_MGR_ENV_NAME) {
         Ok(val) => usage_mgr = val,
         Err(_) => {
             usage_mgr = rocket.config()

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ use std::fs;
 /// Thus, keeping this as a simple constant for now.
 pub const CUBOID_ROOT_PATH: &str = "uploads";
 
+/// Get the absolute path of the cuboid root folder.
 pub fn get_cuboid_root_abs_path() -> String {
     let path = fs::canonicalize(CUBOID_ROOT_PATH);
     let path_str = match path {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,4 @@
+/// SQL database module.
+
+pub mod models;
+pub mod schema;

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -1,0 +1,36 @@
+use super::schema;
+use chrono::prelude::*;
+use schema::cache_roots;
+use schema::cuboids;
+
+#[derive(Identifiable, Queryable)]
+pub struct CacheRoot {
+    pub id: i32,
+    pub path: String,
+}
+
+#[derive(Insertable)]
+#[table_name = "cache_roots"]
+pub struct NewCacheRoot {
+    pub path: String,
+}
+
+#[derive(Identifiable, Queryable)]
+pub struct Cuboid {
+    pub id: u32,
+    pub cache_root: u32,
+    pub cube_key: String,
+    // Diesel doesn't support u32 for add expressions, currently.
+    pub requests: i32,
+    pub created: DateTime<Utc>,
+    pub last_accessed: DateTime<Utc>,
+}
+
+#[derive(Insertable)]
+#[table_name = "cuboids"]
+pub struct NewCuboid {
+    pub cache_root: i32,
+    pub cube_key: String,
+    // Diesel doesn't support u32 for add expressions, currently.
+    pub requests: i32,
+}

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -17,11 +17,10 @@ pub struct NewCacheRoot {
 
 #[derive(Identifiable, Queryable)]
 pub struct Cuboid {
-    pub id: u32,
-    pub cache_root: u32,
+    pub id: i64,
+    pub cache_root: i64,
     pub cube_key: String,
-    // Diesel doesn't support u32 for add expressions, currently.
-    pub requests: i32,
+    pub requests: i64,
     pub created: DateTime<Utc>,
     pub last_accessed: DateTime<Utc>,
 }
@@ -31,6 +30,5 @@ pub struct Cuboid {
 pub struct NewCuboid {
     pub cache_root: i32,
     pub cube_key: String,
-    // Diesel doesn't support u32 for add expressions, currently.
-    pub requests: i32,
+    pub requests: i64,
 }

--- a/src/db/schema.patch
+++ b/src/db/schema.patch
@@ -1,0 +1,19 @@
+diff --git a/src/db/schema.rs b/src/db/schema.rs
+index 3f967d4..d1ae610 100644
+--- a/src/db/schema.rs
++++ b/src/db/schema.rs
+@@ -4,13 +4,13 @@ table! {
+         path -> Text,
+     }
+ }
+ 
+ table! {
+     cuboids (id) {
+-        id -> Integer,
++        id -> BigInt,
+         cache_root -> Integer,
+         cube_key -> Text,
+         requests -> BigInt,
+         created -> Nullable<Text>,
+         last_accessed -> Nullable<Text>,
+     }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -7,7 +7,7 @@ table! {
 
 table! {
     cuboids (id) {
-        id -> Integer,
+        id -> BigInt,
         cache_root -> Integer,
         cube_key -> Text,
         requests -> BigInt,

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,7 +1,7 @@
 table! {
     cache_roots (id) {
         id -> Integer,
-        path -> Varchar,
+        path -> Text,
     }
 }
 
@@ -9,10 +9,10 @@ table! {
     cuboids (id) {
         id -> Integer,
         cache_root -> Integer,
-        cube_key -> Varchar,
-        requests -> Integer,
-        created -> Timestamp,
-        last_accessed -> Timestamp,
+        cube_key -> Text,
+        requests -> BigInt,
+        created -> Nullable<Text>,
+        last_accessed -> Nullable<Text>,
     }
 }
 

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,0 +1,24 @@
+table! {
+    cache_roots (id) {
+        id -> Integer,
+        path -> Varchar,
+    }
+}
+
+table! {
+    cuboids (id) {
+        id -> Integer,
+        cache_root -> Integer,
+        cube_key -> Varchar,
+        requests -> Integer,
+        created -> Timestamp,
+        last_accessed -> Timestamp,
+    }
+}
+
+joinable!(cuboids -> cache_roots (cache_root));
+
+allow_tables_to_appear_in_same_query!(
+    cache_roots,
+    cuboids,
+);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,13 @@
 #![feature(proc_macro_hygiene, decl_macro)]
 
 #[macro_use]
+extern crate diesel;
+
+#[macro_use]
 extern crate rocket;
 
 mod config;
+mod db;
 mod data_manager;
 mod intern;
 mod usage_manager;
@@ -110,7 +114,7 @@ fn download(
 
     // Perform the data-read:
     let fm = ChunkedFileDataManager::new_with_layer(
-        "uploads".to_string(),
+        config::CUBOID_ROOT_PATH.to_string(),
         Vector3 {
             x: 512,
             y: 512,
@@ -192,7 +196,7 @@ fn upload(
 
     // Perform the data-write:
     let fm = ChunkedFileDataManager::new_with_layer(
-        "uploads".to_string(),
+        config::CUBOID_ROOT_PATH.to_string(),
         Vector3 {
             x: 512,
             y: 512,

--- a/src/usage_manager.rs
+++ b/src/usage_manager.rs
@@ -17,12 +17,12 @@ use std::sync;
 use std::sync::mpsc;
 use std::thread;
 
-/// User string names for usage managers.
+/// User string names for selecting usage managers.
 const NONE_MANAGER: &str = "none";
 const CONSOLE_MANAGER: &str = "console";
 const DB_MANAGER: &str = "db";
 
-const DB_URL_ENV_NAME: &str = "BOSSPHORUST_DB_URL";
+const DB_URL_ENV_NAME: &str = "BOSSPHORUS_DB_URL";
 
 pub enum UsageManagerType {
     None,


### PR DESCRIPTION
Initial Sqlite implementation.

This branch logs requests to the DB.
ORM used is Diesel. It doesn't compare well to Django's ORM, but it's better than nothing.

No usage docs yet because considering renaming this to be more closely related to caching.
