### PR TITLE
Implement simple cache management.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -80,7 +80,7 @@ pub fn get_boss_token(rocket: Rocket) -> Result<Rocket, Rocket> {
 }
 
 /// Boss token used for auth.
-pub struct UsageManager(pub String);
+pub struct UsageTracker(pub String);
 
 const USAGE_MGR_ENV_NAME: &str = "USAGE_MGR";
 const USAGE_MGR_ROCKET_CFG: &str = "usage_mgr";
@@ -99,5 +99,5 @@ pub fn get_usage_mgr(rocket: Rocket) -> Result<Rocket, Rocket> {
                 .to_string();
         },
     }
-    Ok(rocket.manage(UsageManager(usage_mgr)))
+    Ok(rocket.manage(UsageTracker(usage_mgr)))
 }

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -7,7 +7,7 @@
 /// want to, you can use `data_manager::get_cuboids_and_indices`, which is
 /// a lot prettier than my Python implementation, if I do say so myself.
 use crate::intern;
-use crate::usage_manager;
+use crate::usage_tracker;
 
 use intern::remote::BossRemote;
 use ndarray::{s, Array, Array3};
@@ -272,7 +272,7 @@ impl DataManager for ChunkedFileDataManager {
             );
 
             if self.track_usage {
-                let mutex = usage_manager::get_sender();
+                let mutex = usage_tracker::get_sender();
                 let tx = mutex.lock().unwrap();
                 if !tx.send(filename.to_string()).is_ok() {
                     // ToDo: log some kind of error that the usage manager went down.

--- a/src/db.rs
+++ b/src/db.rs
@@ -4,22 +4,35 @@ pub mod schema;
 
 extern crate chrono;
 extern crate diesel;
-use super::config;
-use super::usage_manager::UsageManager;
 use chrono::prelude::*;
 use diesel::prelude::*;
 use models::{CacheRoot, Cuboid, NewCacheRoot, NewCuboid};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs;
 use std::option::Option;
 use std::path::Path;
+use std::rc::Rc;
 use std::result::Result;
+use super::config;
+use super::usage_tracker::UsageTracker;
 
 #[cfg(test)]
 pub mod tests;
 
+pub trait Scheduling {
+    /// Returns true if it's time to start removing cuboids from the cache.
+    fn ready_for_cleaning(&self) -> bool;
+}
+
+pub trait Selection {
+    /// Chooses cuboids to remove from the cache.
+    fn select_cuboids_for_removal(&self) -> Vec<Cuboid>;
+}
+
 pub trait LeastRecentlyUsed {
-    /// Find the `num` least recently used cuboids in the cache.
+    /// Find the `num` least recently used cuboids in the cache.  This is one
+    /// selection strategy.
     ///
     /// # Arguments:
     ///
@@ -27,7 +40,160 @@ pub trait LeastRecentlyUsed {
     fn find_lru(&self, num: u32) -> Vec<Cuboid>;
 }
 
-pub struct SqliteCacheManager {
+/// A primitive way of managing the size of the cuboid cache.  Just limit the
+/// maximun number of cuboids stored.
+pub trait LimitNumCuboids {
+    /// Get the max current number of cuboids that the cache should store.
+    fn get_max_cuboids(&self) -> u32;
+
+    /// Set the max number of cuboids that the cache should store.
+    ///
+    /// # Arguments:
+    ///
+    /// * `max` - Max number of cuboids to store.
+    fn set_max_cuboids(&mut self, max: u32);
+
+    /// Get the current number of cuboids stored in the cache.
+    fn size(&self) -> u32;
+
+    /// Set the current number of cuboids in the cache.
+    ///
+    /// # Arguments:
+    ///
+    /// * `num` - Current number of cuboids.
+    fn set_size(&mut self, num: u32);
+
+    /// Update the count by adding the given number.
+    ///
+    /// # Arguments:
+    ///
+    /// * `num` - Increment the count by this value.
+    fn add(&mut self, num: u32);
+
+    /// Update the count by subtracting the given number.  If result would
+    /// be a negative number, count is set to zero.
+    ///
+    /// # Arguments:
+    ///
+    /// * `num` - Deccrement the count by this value.
+    fn sub(&mut self, num: u32);
+}
+
+/// A full, but primitive, cache management strategy.  Limit the maximum
+/// number of cuboids in the cache by evicting the least recently used ones.
+pub struct MaxCountLruStrategy {
+    /// Max number of cuboids stored in the cache.
+    max_cuboids: u32,
+    /// Current number of cuboids stored in the cache.
+    num_cuboids: u32,
+    /// Find cuboids based on least recently used.
+    finder: Rc::<RefCell::<dyn LeastRecentlyUsed>>,
+}
+
+impl Scheduling for MaxCountLruStrategy {
+    fn ready_for_cleaning(&self) -> bool {
+        self.size() > self.get_max_cuboids()
+    }
+}
+
+impl LimitNumCuboids for MaxCountLruStrategy {
+    fn get_max_cuboids(&self) -> u32 {
+        self.max_cuboids
+    }
+
+    fn set_max_cuboids(&mut self, max: u32) {
+        self.max_cuboids = max;
+    }
+
+    fn size(&self) -> u32 {
+        self.num_cuboids
+    }
+
+    fn set_size(&mut self, num: u32) {
+        self.num_cuboids = num;
+    }
+
+    fn add(&mut self, num: u32) {
+        self.num_cuboids += num;
+    }
+
+    fn sub(&mut self, num: u32) {
+        if num > self.num_cuboids {
+            self.num_cuboids = 0;
+        } else {
+            self.num_cuboids -= num;
+        }
+    }
+}
+
+impl Selection for MaxCountLruStrategy {
+    fn select_cuboids_for_removal(&self) -> Vec<Cuboid> {
+        let num_to_remove = self.size() as i64 - self.get_max_cuboids() as i64;
+        if num_to_remove <= 0 {
+            return Vec::<Cuboid>::new();
+        }
+        self.finder.borrow().find_lru(num_to_remove as u32)
+    }
+}
+
+impl MaxCountLruStrategy {
+    pub fn new(max_cuboids: u32, finder: Rc::<RefCell::<dyn LeastRecentlyUsed>>) -> MaxCountLruStrategy {
+        let num_cuboids = 0;
+
+        MaxCountLruStrategy {
+            max_cuboids,
+            num_cuboids,
+            finder,
+        }
+    }
+}
+
+/// Do simple cache management with cache data backed by SQLite.
+pub struct SimpleCacheManager {
+    /// All DB accesses use this object.
+    db: Rc::<RefCell::<SqliteCacheInterface>>,
+    /// Cache management strategy implementation (keep no more than _n_ files; remove least recently used).
+    strategy: MaxCountLruStrategy,
+}
+
+impl UsageTracker for SimpleCacheManager {
+    fn log_request(&mut self, key: String) {
+        if self.db.borrow_mut().log_request(key) {
+            // Added a new cuboid, so check if time to start cleaning cache.
+            self.strategy.add(1);
+            if self.strategy.ready_for_cleaning() {
+                let cuboids = self.strategy.select_cuboids_for_removal();
+                let num_removed = self.db.borrow_mut().clean_cache(cuboids);
+                self.strategy.sub(num_removed);
+            }
+        }
+    }
+}
+
+impl SimpleCacheManager {
+    pub fn new(db: Rc::<RefCell::<SqliteCacheInterface>>, strategy: MaxCountLruStrategy) -> SimpleCacheManager {
+        SimpleCacheManager {
+            db,
+            strategy,
+        }
+    }
+}
+
+/// Wrap file removal for use in testing.
+trait FileRemover {
+    fn remove(&self, path: &Path) -> std::io::Result<()>;
+}
+
+struct RealFileRemover {}
+
+impl FileRemover for RealFileRemover {
+    fn remove(&self, path: &Path) -> std::io::Result<()> {
+        fs::remove_file(path)?;
+        Ok(())
+    }
+}
+/// Provides an API for maintaining cache metadata via SQLite.
+pub struct SqliteCacheInterface {
     /// The connection to the DB.
     connection: SqliteConnection,
     /// id of the cache root in the `cache_roots` table.  Need for inserts into
@@ -37,9 +203,11 @@ pub struct SqliteCacheManager {
     cache_root_map: HashMap<i32, String>,
     /// The byte length of the CUBOID_ROOT_PATH.
     path_len: usize,
+    /// Removes cuboids from the file system.
+    file: Rc<dyn FileRemover>,
 }
 
-impl LeastRecentlyUsed for SqliteCacheManager {
+impl LeastRecentlyUsed for SqliteCacheInterface {
     fn find_lru(&self, num: u32) -> Vec<Cuboid> {
         use schema::cuboids::dsl::*;
         cuboids
@@ -50,52 +218,17 @@ impl LeastRecentlyUsed for SqliteCacheManager {
     }
 }
 
-impl UsageManager for SqliteCacheManager {
-    fn log_request(&self, key: String) {
-        use schema::cuboids::dsl::*;
-
-        // Strip off the root folder because the root, itself, is stored in
-        // the `cache_roots` table.
-        let (_root, remainder) = &key.split_at(self.path_len);
-
-        match diesel::update(cuboids.filter(cube_key.eq(remainder)))
-            .set((
-                requests.eq(requests + 1),
-                last_accessed.eq(Utc::now().naive_utc().to_string()),
-            ))
-            .execute(&self.connection)
-        {
-            Err(err) => println!("Error updating DB: {}", err),
-            Ok(num_rows) => {
-                if num_rows < 1 {
-                    let new_request = NewCuboid {
-                        cache_root: self.cache_root_id,
-                        cube_key: remainder.to_string(),
-                        requests: 1,
-                    };
-                    diesel::insert_into(cuboids)
-                        .values(&new_request)
-                        .execute(&self.connection)
-                        .unwrap_or_else(|err| {
-                            println!("insert failed: {}", err);
-                            0
-                        });
-                }
-            }
-        }
-    }
-}
-
-impl SqliteCacheManager {
+impl SqliteCacheInterface {
     /// Constructor.
     ///
     /// # Arguments:
     ///
     /// * `db_url` - Connection string for the Sqlite DB
-    pub fn new(db_url: &str) -> SqliteCacheManager {
+    /// * `strategy` - Logic for managing size of cache.
+    pub fn new(db_url: &str) -> SqliteCacheInterface {
         let connection =
             SqliteConnection::establish(db_url).expect(&format!("Error connecting to {}", db_url));
-        SqliteCacheManager::init(connection)
+        SqliteCacheInterface::init(connection, Rc::new(RealFileRemover {}))
     }
 
     /// Completes setup of the manager.  Called directly by the `new()` constructor.
@@ -103,26 +236,32 @@ impl SqliteCacheManager {
     /// # Arguments:
     ///
     /// * `connection` - Open Sqlite connection
-    fn init(connection: SqliteConnection) -> SqliteCacheManager {
-        let cache_root_id = SqliteCacheManager::get_cache_root_id(&connection);
+    /// * `file_remover` - Used to remove cuboids from the file system.
+    fn init(connection: SqliteConnection, file_remover: Rc<dyn FileRemover>) -> SqliteCacheInterface {
+        let cache_root_id = SqliteCacheInterface::get_cache_root_id(&connection);
         let mut cache_root_map = HashMap::new();
         cache_root_map.insert(cache_root_id, config::CUBOID_ROOT_PATH.to_string());
         let path_len = config::CUBOID_ROOT_PATH.len();
+        let file = file_remover;
 
-        return SqliteCacheManager {
+        return SqliteCacheInterface {
             connection,
             cache_root_id,
             cache_root_map,
             path_len,
+            file,
         };
     }
 
-    /// Remove the given list of cuboids from the cache.
+    /// Remove the given list of cuboids from the cache.  Returns the number of
+    /// cuboids successfully removed.
     ///
     /// # Arguments
     ///
     /// * `unwanted` - List of cuboids to remove from the cache
-    pub fn clean_cache(&mut self, unwanted: Vec<Cuboid>) {
+    pub fn clean_cache(&mut self, unwanted: Vec<Cuboid>) -> u32 {
+        let mut remove_count: u32 = 0;
+
         for cuboid in unwanted.iter() {
             let root_path = self.get_cache_root_path_from_map(cuboid.cache_root);
             if root_path.is_some() {
@@ -135,9 +274,16 @@ impl SqliteCacheManager {
                     println!("Error removing {}{}", root_path, cuboid.cube_key);
                     continue;
                 }
-                self.remove_cuboid_entry(cuboid.id)
+                if self.remove_cuboid_entry(cuboid.id).is_ok() {
+                    remove_count += 1;
+                } else {
+                    // ToDo: write to log.
+                    println!("Error removing {} from DB", cuboid.cube_key);
+                }
             }
         }
+
+        remove_count
     }
 
     /// Looks up the id of the cache root
@@ -160,7 +306,7 @@ impl SqliteCacheManager {
                     .values(row)
                     .execute(connection)
                     .expect("Could not update database");
-                SqliteCacheManager::get_cache_root_id(connection)
+                SqliteCacheInterface::get_cache_root_id(connection)
             }
         }
     }
@@ -193,20 +339,57 @@ impl SqliteCacheManager {
         }
     }
 
+    fn log_request(&self, key: String) -> bool {
+        use schema::cuboids::dsl::*;
+
+        // Strip off the root folder because the root, itself, is stored in
+        // the `cache_roots` table.
+        let (_root, remainder) = &key.split_at(self.path_len);
+
+        match diesel::update(cuboids.filter(cube_key.eq(remainder)))
+            .set((
+                requests.eq(requests + 1),
+                last_accessed.eq(Utc::now().naive_utc().to_string()),
+            ))
+            .execute(&self.connection)
+        {
+            Err(err) => {
+                println!("Error updating DB: {}", err);
+                false
+            },
+            Ok(num_rows) => {
+                if num_rows > 0 {
+                    return false;
+                }
+                let new_request = NewCuboid {
+                    cache_root: self.cache_root_id,
+                    cube_key: remainder.to_string(),
+                    requests: 1,
+                };
+                match diesel::insert_into(cuboids)
+                    .values(&new_request)
+                    .execute(&self.connection)
+                {
+                    Ok(_) => true,
+                    Err(err) => {
+                        println!("insert failed: {}", err);
+                        false
+                    }
+                }
+            }
+        }
+    }
+
     /// Remove the cuboid's entry from the DB
     ///
     /// # Arguments
     ///
     /// * `cuboid_id` - Cuboid's id in the DB
-    fn remove_cuboid_entry(&self, cuboid_id: i64) {
+    fn remove_cuboid_entry(&self, cuboid_id: i64) -> QueryResult<()> {
         use schema::cuboids::dsl::*;
-        if diesel::delete(cuboids.filter(id.eq(cuboid_id)))
-            .execute(&self.connection)
-            .is_err()
-        {
-            // ToDo: write to log.
-            println!("Could not delete cuboid with id: {}", cuboid_id);
-        }
+        diesel::delete(cuboids.filter(id.eq(cuboid_id)))
+            .execute(&self.connection)?;
+        Ok(())
     }
 
     /// Remove the cuboid's file
@@ -216,7 +399,8 @@ impl SqliteCacheManager {
     /// * `cuboid_path` - Full path to the cuboid
     fn remove_cuboid_file(&self, cuboid_path: &str) -> std::io::Result<()> {
         let path = Path::new(cuboid_path);
-        fs::remove_file(path)?;
+        //fs::remove_file(path)?;
+        self.file.remove(path)?;
         Ok(())
     }
 }

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -1,137 +1,50 @@
-use super::models::Cuboid;
-use super::schema;
-use super::{LeastRecentlyUsed, SqliteCacheManager};
-use crate::config;
-use crate::usage_manager::UsageManager;
-use chrono::prelude::*;
+use crate::db::{FileRemover, SqliteCacheInterface};
 use diesel::prelude::*;
+use std::cell::RefCell;
+use std::path::Path;
+use std::rc::Rc;
+
+pub mod max_count_lru_strategy;
+pub mod simple_cache_manager;
+pub mod sqlite;
 
 diesel_migrations::embed_migrations!();
 
+struct MockFileRemover {
+    /// Stores calls to the mock file remover.
+    calls: Rc<RefCell<Vec<String>>>,
+}
+
+impl FileRemover for MockFileRemover {
+    fn remove(&self, path: &Path) -> std::io::Result<()> {
+        match path.to_str() {
+            Some(p) => self.calls.borrow_mut().push(p.to_string()),
+            None => (),
+        }
+        Ok(())
+    }
+}
+
+impl MockFileRemover {
+    fn new(calls: Rc<RefCell<Vec<String>>>) -> MockFileRemover {
+        MockFileRemover {
+            calls,
+        }
+    }
+}
+
+struct SqlCacheInterfaceTestItems {
+    sql_mgr: SqliteCacheInterface,
+    remove_calls: Rc<RefCell<Vec<String>>>,
+}
+
 /// Set up an in-memory Sqlite DB and return a SqliteCacheManager for testing.
-fn setup_db() -> SqliteCacheManager {
+fn setup_db() -> SqlCacheInterfaceTestItems {
     let connection = SqliteConnection::establish(":memory:").unwrap();
     embedded_migrations::run(&connection).unwrap();
-    SqliteCacheManager::init(connection)
-}
+    let remove_calls = Rc::new(RefCell::new(Vec::<String>::new()));
+    let clone = Rc::clone(&remove_calls);
+    let sql_mgr = SqliteCacheInterface::init(connection, Rc::new(MockFileRemover::new(clone)));
 
-#[test]
-fn test_log_new_request() {
-    use super::schema::cuboids::dsl::*;
-
-    let sql_mgr = setup_db();
-    let key = "/new_key";
-    sql_mgr.log_request(format!("{}{}", config::CUBOID_ROOT_PATH, key));
-    assert_eq!(
-        Ok((key.to_string(), 1)),
-        cuboids
-            .select((cube_key, requests))
-            .filter(cube_key.eq(key))
-            .first::<(String, i64)>(&sql_mgr.connection)
-    );
-}
-
-#[test]
-fn test_log_repeated_request() {
-    use super::schema::cuboids::dsl::*;
-
-    let sql_mgr = setup_db();
-    let key = "/my_key";
-    sql_mgr.log_request(format!("{}{}", config::CUBOID_ROOT_PATH, key));
-    sql_mgr.log_request(format!("{}{}", config::CUBOID_ROOT_PATH, key));
-    assert_eq!(
-        Ok((key.to_string(), 2)),
-        cuboids
-            .select((cube_key, requests))
-            .filter(cube_key.eq(key))
-            .first::<(String, i64)>(&sql_mgr.connection)
-    );
-}
-
-#[test]
-fn test_find_lru() {
-    use super::schema::cuboids::dsl::*;
-
-    let sql_mgr = setup_db();
-    let key = "/my_key";
-    let rows_to_get = 2;
-    let rows_to_insert = 4;
-    let exp_rows: Vec<Cuboid> = (0..rows_to_insert)
-        .map(|i| {
-            // Generate rows from most recently accessed to least.
-            let timestamp = Utc.ymd(2020, 4, 19).and_hms(23 - i, 0, 0).naive_utc();
-            Cuboid {
-                id: (i + 1) as i64,
-                cache_root: sql_mgr.cache_root_id,
-                cube_key: format!("{}/{}", key, i),
-                requests: i as i64,
-                created: timestamp,
-                last_accessed: timestamp,
-            }
-        })
-        .collect();
-
-    for row in &exp_rows {
-        diesel::insert_into(cuboids)
-            .values(row)
-            .execute(&sql_mgr.connection)
-            .unwrap();
-    }
-
-    let actual = sql_mgr.find_lru(rows_to_get);
-
-    assert_eq!(rows_to_get as usize, actual.len());
-
-    // Rows returned show be equal to the last n rows of `exp_rows`.
-    for row in exp_rows.iter().rev().zip(actual.iter()) {
-        assert_eq!(row.0, row.1);
-    }
-}
-
-#[test]
-fn test_get_cache_root_path_from_map_new_lookup() {
-    use schema::cache_roots::dsl::*;
-
-    let mut sql_mgr = setup_db();
-    let root = "/some/folder";
-    let cache_root_id = 100;
-    diesel::insert_into(cache_roots)
-        .values(&(id.eq(cache_root_id), path.eq(root)))
-        .execute(&sql_mgr.connection)
-        .expect("Could not add cache root");
-    let actual = sql_mgr.get_cache_root_path_from_map(cache_root_id).unwrap();
-    assert_eq!(root, actual);
-}
-
-#[test]
-fn test_get_cache_root_path_from_map_existing_lookup() {
-    let mut sql_mgr = setup_db();
-    let cache_root_id = 100;
-    let root_path = "/some/other/folder";
-    sql_mgr
-        .cache_root_map
-        .insert(cache_root_id, root_path.to_string());
-    assert_eq!(
-        root_path,
-        sql_mgr.get_cache_root_path_from_map(cache_root_id).unwrap()
-    );
-}
-
-#[test]
-fn test_remove_cuboid_entry() {
-    use super::schema::cuboids::dsl::*;
-
-    let sql_mgr = setup_db();
-    let key = "/new_key";
-    sql_mgr.log_request(format!("{}{}", config::CUBOID_ROOT_PATH, key));
-
-    let row = sql_mgr.find_lru(1);
-
-    sql_mgr.remove_cuboid_entry(row[0].id);
-
-    let results = cuboids
-        .select(id)
-        .filter(id.eq(row[0].id))
-        .first::<i64>(&sql_mgr.connection);
-    assert_eq!(false, results.is_ok());
+    SqlCacheInterfaceTestItems { sql_mgr, remove_calls }
 }

--- a/src/db/tests/max_count_lru_strategy.rs
+++ b/src/db/tests/max_count_lru_strategy.rs
@@ -1,0 +1,67 @@
+use crate::db::models::Cuboid;
+use crate::db::{LeastRecentlyUsed, LimitNumCuboids, MaxCountLruStrategy, Scheduling, Selection};
+use chrono::prelude::*;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+struct MockLru {}
+
+impl LeastRecentlyUsed for MockLru {
+    /// Return the number of rows requested.  For these tests, row content
+    /// doesn't really matter.
+    fn find_lru(&self, num: u32) -> Vec<Cuboid> {
+        let key = "cube";
+        let rows: Vec<Cuboid> = (0..num)
+            .map(|i| {
+                let timestamp = Utc.ymd(2020, 4, 19).and_hms(23 - i, 0, 0).naive_utc();
+                Cuboid {
+                    id: (i + 1) as i64,
+                    cache_root: 1,
+                    cube_key: format!("{}/{}", key, i),
+                    requests: i as i64,
+                    created: timestamp,
+                    last_accessed: timestamp,
+                }
+            })
+            .collect();
+        rows
+    }
+}
+
+#[test]
+fn test_ready_for_cleaning_should_be_yes() {
+    let mut strat = MaxCountLruStrategy::new(100, Rc::new(RefCell::new(MockLru {})));
+    strat.set_size(101);
+    assert!(strat.ready_for_cleaning());
+}
+
+#[test]
+fn test_ready_for_cleaning_should_be_no() {
+    let mut strat = MaxCountLruStrategy::new(100, Rc::new(RefCell::new(MockLru {})));
+    strat.set_size(100);
+    assert_eq!(false, strat.ready_for_cleaning());
+}
+
+#[test]
+fn test_sub_with_u32_overflow() {
+    let mut strat = MaxCountLruStrategy::new(100, Rc::new(RefCell::new(MockLru {})));
+    strat.set_size(100);
+    strat.sub(102);
+    assert_eq!(0, strat.size());
+}
+
+#[test]
+fn test_select_cuboids_for_removal_should_be_none() {
+    let mut strat = MaxCountLruStrategy::new(100, Rc::new(RefCell::new(MockLru {})));
+    strat.set_size(100);
+    let actual = strat.select_cuboids_for_removal();
+    assert_eq!(0, actual.len());
+}
+
+#[test]
+fn test_select_cuboids_for_removal() {
+    let mut strat = MaxCountLruStrategy::new(100, Rc::new(RefCell::new(MockLru {})));
+    strat.set_size(104);
+    let actual = strat.select_cuboids_for_removal();
+    assert_eq!(4, actual.len());
+}

--- a/src/db/tests/simple_cache_manager.rs
+++ b/src/db/tests/simple_cache_manager.rs
@@ -1,0 +1,52 @@
+use crate::config;
+use crate::db::{LimitNumCuboids, MaxCountLruStrategy, SimpleCacheManager};
+use crate::usage_tracker::UsageTracker;
+use std::cell::RefCell;
+use std::rc::Rc;
+use super::{SqlCacheInterfaceTestItems};
+
+const MAX_COUNT: u32 = 10;
+
+struct TestItems {
+    cache_mgr: SimpleCacheManager,
+    remove_calls: Rc<RefCell<Vec<String>>>,
+}
+
+fn setup() -> TestItems {
+    let SqlCacheInterfaceTestItems { sql_mgr, remove_calls } = super::setup_db();
+    let db = Rc::new(RefCell::new(sql_mgr));
+    let clone = Rc::clone(&db);
+    let strat = MaxCountLruStrategy::new(MAX_COUNT, clone);
+    TestItems { 
+        cache_mgr: SimpleCacheManager::new(db, strat),
+        remove_calls,
+    }
+}
+
+#[test]
+fn test_cache_management() {
+    let TestItems { mut cache_mgr, remove_calls } = setup();
+
+    let key = "coll/exp/chan";
+    let num_reqs = MAX_COUNT + 5;
+    let requests: Vec<String> = (0..num_reqs)
+        .map(|i| {
+            format!("{}/{}/{}", config::CUBOID_ROOT_PATH, key, i)
+        })
+        .collect();
+
+    for (i, req) in requests.iter().enumerate() {
+        cache_mgr.log_request(req.to_string());
+        if i >= MAX_COUNT  as usize {
+            // Once there are MAX_COUNT cuboids in the cache, then there
+            // should be a removal of the oldest cuboid whenever a new one
+            // gets added.
+            let ind = i - MAX_COUNT as usize;
+            assert_eq!(requests[ind], remove_calls.borrow()[ind]);
+        }
+    }
+
+    let exp_removes = (num_reqs - MAX_COUNT) as usize;
+    assert_eq!(exp_removes, remove_calls.borrow().len());
+    assert_eq!(MAX_COUNT, cache_mgr.strategy.size());
+}

--- a/src/db/tests/sqlite.rs
+++ b/src/db/tests/sqlite.rs
@@ -1,0 +1,147 @@
+use crate::db::models::Cuboid;
+use crate::db::{LeastRecentlyUsed, schema};
+use crate::config;
+use chrono::prelude::*;
+use diesel::prelude::*;
+use super::{SqlCacheInterfaceTestItems};
+
+#[test]
+fn test_log_new_request() {
+    use schema::cuboids::dsl::*;
+
+    let SqlCacheInterfaceTestItems { sql_mgr, .. } = super::setup_db();
+    let key = "/new_key";
+    let actual = sql_mgr.log_request(format!("{}{}", config::CUBOID_ROOT_PATH, key));
+    assert_eq!(true, actual);
+    assert_eq!(
+        Ok((key.to_string(), 1)),
+        cuboids
+            .select((cube_key, requests))
+            .filter(cube_key.eq(key))
+            .first::<(String, i64)>(&sql_mgr.connection)
+    );
+}
+
+#[test]
+fn test_log_repeated_request() {
+    use schema::cuboids::dsl::*;
+
+    let SqlCacheInterfaceTestItems { sql_mgr, .. } = super::setup_db();
+    let key = "/my_key";
+    assert_eq!(true, sql_mgr.log_request(format!("{}{}", config::CUBOID_ROOT_PATH, key)));
+    assert_eq!(false, sql_mgr.log_request(format!("{}{}", config::CUBOID_ROOT_PATH, key)));
+    assert_eq!(
+        Ok((key.to_string(), 2)),
+        cuboids
+            .select((cube_key, requests))
+            .filter(cube_key.eq(key))
+            .first::<(String, i64)>(&sql_mgr.connection)
+    );
+}
+
+#[test]
+fn test_find_lru() {
+    use schema::cuboids::dsl::*;
+
+    let SqlCacheInterfaceTestItems { sql_mgr, .. } = super::setup_db();
+    let key = "/my_key";
+    let rows_to_get = 2;
+    let rows_to_insert = 4;
+    let exp_rows: Vec<Cuboid> = (0..rows_to_insert)
+        .map(|i| {
+            // Generate rows from most recently accessed to least.
+            let timestamp = Utc.ymd(2020, 4, 19).and_hms(23 - i, 0, 0).naive_utc();
+            Cuboid {
+                id: (i + 1) as i64,
+                cache_root: sql_mgr.cache_root_id,
+                cube_key: format!("{}/{}", key, i),
+                requests: i as i64,
+                created: timestamp,
+                last_accessed: timestamp,
+            }
+        })
+        .collect();
+
+    for row in &exp_rows {
+        diesel::insert_into(cuboids)
+            .values(row)
+            .execute(&sql_mgr.connection)
+            .unwrap();
+    }
+
+    let actual = sql_mgr.find_lru(rows_to_get);
+
+    assert_eq!(rows_to_get as usize, actual.len());
+
+    // Rows returned show be equal to the last n rows of `exp_rows`.
+    for row in exp_rows.iter().rev().zip(actual.iter()) {
+        assert_eq!(row.0, row.1);
+    }
+}
+
+#[test]
+fn test_get_cache_root_path_from_map_new_lookup() {
+    use schema::cache_roots::dsl::*;
+
+    let SqlCacheInterfaceTestItems { mut sql_mgr, .. } = super::setup_db();
+    let root = "/some/folder";
+    let cache_root_id = 100;
+    diesel::insert_into(cache_roots)
+        .values(&(id.eq(cache_root_id), path.eq(root)))
+        .execute(&sql_mgr.connection)
+        .expect("Could not add cache root");
+    let actual = sql_mgr.get_cache_root_path_from_map(cache_root_id).unwrap();
+    assert_eq!(root, actual);
+}
+
+#[test]
+fn test_get_cache_root_path_from_map_existing_lookup() {
+    let SqlCacheInterfaceTestItems { mut sql_mgr, .. } = super::setup_db();
+    let cache_root_id = 100;
+    let root_path = "/some/other/folder";
+    sql_mgr
+        .cache_root_map
+        .insert(cache_root_id, root_path.to_string());
+    assert_eq!(
+        root_path,
+        sql_mgr.get_cache_root_path_from_map(cache_root_id).unwrap()
+    );
+}
+
+#[test]
+fn test_remove_cuboid_entry() {
+    use schema::cuboids::dsl::*;
+
+    let SqlCacheInterfaceTestItems { sql_mgr, .. } = super::setup_db();
+    let key = "/new_key";
+    assert_eq!(true, sql_mgr.log_request(format!("{}{}", config::CUBOID_ROOT_PATH, key)));
+
+    let row = sql_mgr.find_lru(1);
+
+    assert!(sql_mgr.remove_cuboid_entry(row[0].id).is_ok());
+
+    let results = cuboids
+        .select(id)
+        .filter(id.eq(row[0].id))
+        .first::<i64>(&sql_mgr.connection);
+    assert_eq!(false, results.is_ok());
+}
+
+#[test]
+fn test_clean_cache() {
+    let SqlCacheInterfaceTestItems { mut sql_mgr, remove_calls } = super::setup_db();
+    let key1 = "/oldest_key";
+    let full_key1 = format!("{}{}", config::CUBOID_ROOT_PATH, key1);
+    assert_eq!(true, sql_mgr.log_request(full_key1.to_string()));
+
+    let key2 = "/not_as_old_key";
+    assert_eq!(true, sql_mgr.log_request(format!("{}{}", config::CUBOID_ROOT_PATH, key2)));
+
+    let row = sql_mgr.find_lru(1);
+    assert_eq!(key1, row[0].cube_key);
+
+    let count = sql_mgr.clean_cache(row);
+    assert_eq!(1, count);
+    assert_eq!(1, remove_calls.borrow().len());
+    assert_eq!(full_key1, remove_calls.borrow()[0]);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,4 @@ pub mod config;
 pub mod data_manager;
 pub mod db;
 pub mod intern;
-pub mod usage_manager;
+pub mod usage_tracker;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 extern crate rocket;
 
 
-use bossphorus::usage_manager::{self, UsageManagerType};
+use bossphorus::usage_tracker::{self, UsageTrackerType};
 use bossphorus::config;
 use bossphorus::data_manager::{BossDBRelayDataManager, ChunkedFileDataManager, DataManager, Vector3};
 
@@ -358,15 +358,15 @@ pub struct TrackingUsage(pub bool);
 /// Start the usage manager if it's turned on.  If manager started, the
 /// TrackingUsage state variable is set to true.
 fn start_usage_mgr(rocket: Rocket) -> Result<Rocket, Rocket> {
-    let mgr = rocket.state::<config::UsageManager>();
+    let mgr = rocket.state::<config::UsageTracker>();
     let tracking: bool = match mgr {
         None => false,
         Some(mgr_type) => {
-            let kind = usage_manager::get_manager_type(&mgr_type.0);
-            if let UsageManagerType::None = kind {
+            let kind = usage_tracker::get_manager_type(&mgr_type.0);
+            if let UsageTrackerType::None = kind {
                 false
             } else {
-                usage_manager::run(kind);
+                usage_tracker::run(kind);
                 true
             }
         }

--- a/src/usage_tracker.rs
+++ b/src/usage_tracker.rs
@@ -1,53 +1,61 @@
-/// Usage management module.
+/// Usage Tracker module.
 ///
 /// Tracks usage of the cached cuboids stored locally on disk.
 ///
 /// A single thread receives keys from the Rocket worker threads as cuboids are
 /// accessed.
-use super::db::SqliteCacheManager;
+use super::db::{MaxCountLruStrategy, SimpleCacheManager, SqliteCacheInterface};
+use std::cell::RefCell;
 use std::env;
+use std::rc::Rc;
 use std::sync;
 use std::sync::mpsc;
 use std::thread;
 
 /// User string names for selecting usage managers.
-const NONE_MANAGER: &str = "none";
-const CONSOLE_MANAGER: &str = "console";
-const DB_MANAGER: &str = "db";
+const NONE_TRACKER: &str = "none";
+const CONSOLE_TRACKER: &str = "console";
+const DB_TRACKER: &str = "db";
+
+const DEFAULT_MAX_CUBOIDS: u32 = 1000;
 
 const DB_URL_ENV_NAME: &str = "BOSSPHORUS_DB_URL";
 
-pub enum UsageManagerType {
+pub enum UsageTrackerType {
     None,
     Console,
     Sqlite,
 }
 
 /// Map string name of usage manager to enum.  If no match is found, return
-/// UsageManagerType::None.
-pub fn get_manager_type(name: &str) -> UsageManagerType {
+/// UsageTrackerType::None.
+pub fn get_manager_type(name: &str) -> UsageTrackerType {
     let lowered = name.to_lowercase();
     match lowered.as_str() {
-        CONSOLE_MANAGER => UsageManagerType::Console,
-        NONE_MANAGER => UsageManagerType::None,
-        DB_MANAGER => UsageManagerType::Sqlite,
+        CONSOLE_TRACKER => UsageTrackerType::Console,
+        NONE_TRACKER => UsageTrackerType::None,
+        DB_TRACKER => UsageTrackerType::Sqlite,
         _ => {
-            println!("Warning, got unknown user manager: {}", name);
-            UsageManagerType::None
+            println!("Warning, got unknown usage tracker: {}", name);
+            UsageTrackerType::None
         }
     }
 }
 
-fn usage_manager_factory(kind: UsageManagerType) -> Box<dyn UsageManager> {
+fn usage_manager_factory(kind: UsageTrackerType) -> Box<dyn UsageTracker> {
     match kind {
-        UsageManagerType::None => Box::new(NoneManager {}),
-        UsageManagerType::Console => Box::new(ConsoleUsageManager {}),
-        UsageManagerType::Sqlite => {
+        UsageTrackerType::None => Box::new(NoneTracker {}),
+        UsageTrackerType::Console => Box::new(ConsoleUsageTracker {}),
+        UsageTrackerType::Sqlite => {
             let db_url = env::var(DB_URL_ENV_NAME).expect(&format!(
                 "{} environment variable must be set",
                 &DB_URL_ENV_NAME
             ));
-            Box::new(SqliteCacheManager::new(&db_url))
+            let db_interface = SqliteCacheInterface::new(&db_url);
+            let rc_db_iface = Rc::new(RefCell::new(db_interface));
+            let clone = Rc::clone(&rc_db_iface);
+            let strategy = MaxCountLruStrategy::new(DEFAULT_MAX_CUBOIDS, rc_db_iface);
+            Box::new(SimpleCacheManager::new(clone, strategy))
         }
     }
 }
@@ -74,8 +82,8 @@ pub fn get_sender() -> &'static sync::Mutex<mpsc::Sender<String>> {
 ///
 /// * `kind` - Which usage manager to start
 /// * `cuboid_root_path` - Root of cached cuboids
-pub fn run(kind: UsageManagerType) {
-    if let UsageManagerType::None = kind {
+pub fn run(kind: UsageTrackerType) {
+    if let UsageTrackerType::None = kind {
         return;
     }
 
@@ -88,32 +96,32 @@ pub fn run(kind: UsageManagerType) {
     }
 
     thread::spawn(move || {
-        let usage_mgr = usage_manager_factory(kind);
+        let mut usage_mgr = usage_manager_factory(kind);
         for key in rx {
             usage_mgr.log_request(key);
         }
     });
 }
 
-pub trait UsageManager {
+pub trait UsageTracker {
     /// Log request to console, file, or DB.
-    fn log_request(&self, key: String);
+    fn log_request(&mut self, key: String);
 }
 
-/// Empty manager.
-pub struct NoneManager {}
+/// Empty tracker.
+pub struct NoneTracker {}
 
-impl UsageManager for NoneManager {
-    fn log_request(&self, _key: String) {}
+impl UsageTracker for NoneTracker {
+    fn log_request(&mut self, _key: String) {}
 }
 
-/// Proof of concept manager.
-pub struct ConsoleUsageManager {}
+/// Proof of concept tracker.
+pub struct ConsoleUsageTracker {}
 
-impl UsageManager for ConsoleUsageManager {
+impl UsageTracker for ConsoleUsageTracker {
     /// Most basic manager - output to console.
 
-    fn log_request(&self, key: String) {
+    fn log_request(&mut self, key: String) {
         println!("Request: {}", key);
     }
 }


### PR DESCRIPTION
Keep no more than _n_ cuboids in the cache.  Evict the least recently
used.

Rename usage_manager to usage_tracker.

ToDo:
* Ensure DB created at start up.
* Clean up configuration.
* Activate cache management by default.