### PR TITLE
Turn on cache management by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,18 @@ It is bewildering how much faster this is than the Python implementation.
 
 See [Feature Parity](docs/Features.md) for more information.
 
+
+## Disk Usage
+
+Bossphorus caches cuboids in the `uploads` folder that's created in the current
+working directory.  Currently, it will cache up to 1000 cuboids in this folder.
+The least recently used cuboids are removed when the cuboid limit is reached.
+
+
 ## Configuration
 
 Environment variables have precedence over the `Rocket.toml` config file.
+
 
 ### Environment Variables
 
@@ -41,7 +50,8 @@ bosstoken = "public"
 
 ## Development
 
-Blosc must be installed manually via a package manager to build.
+Blosc must be installed manually via a package manager to build.  SQLite is
+required, but it included with MacOS by default.
 
 For MacOS:
 
@@ -49,10 +59,16 @@ For MacOS:
 brew install c-blosc
 ```
 
-For Ubuntu-like:
+For Debian based Linux distros:
 
 ```shell
-sudo apt install libblosc-dev
+sudo apt-get install libblosc-dev sqlite3
+```
+
+For RPM based Linux distros:
+
+```shell
+sudo yum install blosc sqlite
 ```
 
 
@@ -61,6 +77,7 @@ Due to use of the Rocket web server crate, the nightly Rust toolchain must be us
 ```shell
 rustup override set nightly
 ```
+
 
 ## Releases
 

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -3,11 +3,9 @@ address = "localhost"
 port = 8090
 bosshost = "api.bossdb.io"
 bosstoken = "public"
-bossusage_mgr = "none"
 
 [production]
 address = "0.0.0.0"
 port = 8090
 bosshost = "api.bossdb.io"
 bosstoken = "public"
-bossusage_mgr = "none"

--- a/src/main.rs
+++ b/src/main.rs
@@ -355,14 +355,14 @@ fn not_found(_req: &Request) { /* .. */
 /// Is usage tracking enabled?
 pub struct TrackingUsage(pub bool);
 
-/// Start the usage manager if it's turned on.  If manager started, the
+/// Start the usage tracker if it's turned on.  If tracker started, the
 /// TrackingUsage state variable is set to true.
-fn start_usage_mgr(rocket: Rocket) -> Result<Rocket, Rocket> {
+fn start_usage_tracker(rocket: Rocket) -> Result<Rocket, Rocket> {
     let mgr = rocket.state::<config::UsageTracker>();
     let tracking: bool = match mgr {
         None => false,
         Some(mgr_type) => {
-            let kind = usage_tracker::get_manager_type(&mgr_type.0);
+            let kind = usage_tracker::get_tracker_type(&mgr_type.0);
             if let UsageTrackerType::None = kind {
                 false
             } else {
@@ -389,10 +389,10 @@ fn main() {
         .attach(AdHoc::on_attach("Boss Host", config::get_boss_host))
         .attach(AdHoc::on_attach("Boss Token", config::get_boss_token))
         .attach(AdHoc::on_attach(
-            "Usage Manager Config",
-            config::get_usage_mgr,
+            "Usage Tracker Config",
+            config::get_usage_tracker,
         ))
-        .attach(AdHoc::on_attach("Usage Manager Start", start_usage_mgr))
+        .attach(AdHoc::on_attach("Usage Tracker Start", start_usage_tracker))
         .register(catchers![not_found])
         .launch();
 }


### PR DESCRIPTION
Use SQLite to track cuboids in the cache.
Finish name change from usage manager to usage tracker.
Update docs.

Lost momentum on this due to work being so busy, so turned on caching w/o updating our current config file. For now, the DB will be placed in the current working directory just like the `uploads` folder is placed in the current working directory.